### PR TITLE
FIX: header links text-decoration none

### DIFF
--- a/OxygenShopMarc/style.css
+++ b/OxygenShopMarc/style.css
@@ -70,6 +70,7 @@
 }
 
 .navigation-li a{
+  text-decoration: none;
   color: #08A6E4;
   font-family: "Comic Sans";
   font-style: solid;


### PR DESCRIPTION
Quité la decoración que traen por defecto los enlaces. @mcpicornell 